### PR TITLE
feat: adiciona containerizacao com Docker para backend e frontend

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,10 @@
+venv/
+.env
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.db
+*.json
+.git
+.gitignore

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,30 @@
+# Imagem base leve do Python
+FROM python:3.10-slim
+
+# Evita que o Python escreva arquivos .pyc no disco
+ENV PYTHONDONTWRITEBYTECODE=1
+# Evita que o Python faça buffer das saídas de log (mostra em tempo real no console)
+ENV PYTHONUNBUFFERED=1
+
+# Define o diretório de trabalho
+WORKDIR /app
+
+# Instala dependências de sistema necessárias para compilar bibliotecas C (como psycopg2)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libpq-dev \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copia e instala as dependências do Python
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copia o código-fonte do backend
+COPY . .
+
+# Expõe a porta da API Flask
+EXPOSE 5001
+
+# Comando para rodar a aplicação em desenvolvimento
+CMD ["python", "api.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+services:
+  # --- BACKEND (Flask API) ---
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: dito_efeito_backend
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
+    ports:
+      - "5001:5001"
+    env_file:
+      - ./backend/.env
+    volumes:
+      # Sincroniza o código local com o container para refletir alterações sem reconstruir
+      - ./backend:/app
+      # Protege a pasta de dependências do container contra sobreposição local
+      - /app/venv
+      # Cria um volume persistente para o cache de modelos do Hugging Face (BERTimbau)
+      - hf_cache:/root/.cache/huggingface
+    restart: always
+
+  # --- FRONTEND (React Dev Server) ---
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      target: dev-stage # Executa no estágio de desenvolvimento
+    container_name: dito_efeito_frontend
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
+    ports:
+      - "5173:5173"
+    volumes:
+      # Sincroniza o código do front para HMR (Hot Module Replacement)
+      - ./frontend:/app
+      # Evita que a node_modules local apague a node_modules do container
+      - /app/node_modules
+    depends_on:
+      - backend
+    restart: always
+
+volumes:
+  hf_cache:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,25 @@
+# --- ESTÁGIO 1: Base de desenvolvimento ---
+FROM node:22-alpine AS dev-stage
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 5173
+# Roda o Vite expondo a rede externa para aceitar conexões fora do container
+CMD ["npm", "run", "dev", "--", "--host"]
+
+# --- ESTÁGIO 2: Build de produção ---
+FROM node:22-alpine AS build-stage
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# --- ESTÁGIO 3: Servidor de produção com Nginx ---
+FROM nginx:stable-alpine AS prod-stage
+# Copia o build estático do Vite para a pasta de arquivos públicos do Nginx
+COPY --from=build-stage /app/dist /usr/share/nginx/html
+# Copia uma configuração customizada do Nginx se necessário (opcional)
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
- Adiciona Dockerfile do backend (Python 3.10-slim + Flask)
- Adiciona Dockerfile do frontend (Node 22-alpine + Vite dev server)
- Adiciona docker-compose.yml orquestrando backend e frontend
- Adiciona .dockerignore para backend e frontend
- Backend exposto na porta 5001, frontend na porta 5173
- Volume persistente hf_cache para modelos Hugging Face (BERTimbau)
- DNS configurado (8.8.8.8) para resolver problemas de rede no build