### PR TITLE
feat(deploy): preparar projeto para producao no Render e Vercel

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -5,6 +5,8 @@ __pycache__/
 *.pyo
 *.pyd
 .db
-*.json
+# Exclui apenas o arquivo de configuração local (checkpoint), não os dados de fallback
+config_data.json
 .git
 .gitignore
+tests/

--- a/backend/api.py
+++ b/backend/api.py
@@ -43,7 +43,15 @@ METRICS_JSON_PATH = os.path.join(
 )
 
 app = Flask(__name__)
-CORS(app)
+
+# CORS configurado para aceitar o frontend local e o de produção (Vercel)
+# Em produção, defina FRONTEND_URL no painel de variáveis do Render
+_FRONTEND_URL = os.environ.get("FRONTEND_URL", "")
+_CORS_ORIGINS = ["http://localhost:5173", "http://localhost:5174"]
+if _FRONTEND_URL:
+    _CORS_ORIGINS.append(_FRONTEND_URL)
+
+CORS(app, origins=_CORS_ORIGINS)
 
 BASE_SENADO = "https://legis.senado.leg.br/dadosabertos"
 BASE_CAMARA = "https://dadosabertos.camara.leg.br/api/v2"

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,170 @@
+# 🚀 Guia de Deploy — Dito e Feito
+
+Este guia ensina como colocar o projeto **Dito e Feito** em produção usando **Render** (backend) e **Vercel** (frontend).
+
+---
+
+## Pré-requisitos
+
+Antes de começar, você precisa ter acesso às seguintes chaves/credenciais:
+
+| Serviço | Onde obter | Variável |
+|---|---|---|
+| **Supabase** | [supabase.com](https://supabase.com) → Seu projeto → Settings → Database | `DATABASE_URL` |
+| **Groq** | [console.groq.com](https://console.groq.com) → API Keys | `GROQ_API_KEY` |
+| **OpenRouter** | [openrouter.ai](https://openrouter.ai) → Keys | `OPENROUTER_API_KEY` |
+
+---
+
+## 1. Deploy do Backend no Render
+
+### 1.1 Criar o serviço
+
+1. Acesse [render.com](https://render.com) e faça login
+2. Clique em **New → Web Service**
+3. Conecte seu repositório GitHub (`unb-mds/2026-1-Squad4-Dito_e_Feito`)
+4. Configure o serviço:
+
+| Campo | Valor |
+|---|---|
+| **Name** | `dito-e-feito-backend` |
+| **Region** | `Ohio (US East)` ou qualquer disponível |
+| **Branch** | `main` |
+| **Root Directory** | `backend` |
+| **Runtime** | `Docker` |
+| **Dockerfile Path** | `./Dockerfile` |
+
+> O Render vai usar o `CMD` do Dockerfile (`gunicorn -b 0.0.0.0:5001 api:app`) automaticamente.
+
+### 1.2 Configurar as Variáveis de Ambiente
+
+No painel do Render, vá em **Environment → Add Environment Variable** e adicione:
+
+```
+DATABASE_URL   = postgresql://postgres:SUA_SENHA@db.SEU_PROJETO.supabase.co:5432/postgres
+GROQ_API_KEY   = gsk_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+OPENROUTER_API_KEY = sk-or-v1-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+FRONTEND_URL   = https://dito-e-feito.vercel.app
+```
+
+> ⚠️ **NUNCA** coloque as chaves reais no código ou no repositório. Use sempre o painel de variáveis de ambiente do Render.
+> 
+> 💡 `FRONTEND_URL` é usada pelo backend para configurar o CORS. Adicione a URL exata da Vercel após o deploy do frontend.
+
+### 1.3 Como obter a DATABASE_URL do Supabase
+
+1. Acesse [supabase.com](https://supabase.com) e abra seu projeto
+2. Vá em **Settings → Database**
+3. Copie a **Connection String** no formato `postgresql://postgres:[SUA-SENHA]@db.[SEU-PROJETO].supabase.co:5432/postgres`
+4. Substitua `[SUA-SENHA]` pela senha do banco
+
+### 1.4 Deploy
+
+Clique em **Create Web Service**. O Render vai:
+1. Fazer o build do Docker
+2. Iniciar o Gunicorn na porta 5001
+3. Fornecer uma URL pública como `https://dito-e-feito-backend.onrender.com`
+
+**Guarde essa URL — você vai precisar dela para o frontend.**
+
+---
+
+## 2. Deploy do Frontend na Vercel
+
+### 2.1 Criar o projeto
+
+1. Acesse [vercel.com](https://vercel.com) e faça login
+2. Clique em **New Project**
+3. Importe o repositório `unb-mds/2026-1-Squad4-Dito_e_Feito`
+4. Configure o projeto:
+
+| Campo | Valor |
+|---|---|
+| **Framework Preset** | `Vite` |
+| **Root Directory** | `frontend` |
+| **Build Command** | `npm run build` |
+| **Output Directory** | `dist` |
+
+### 2.2 Configurar a URL do Backend
+
+O frontend precisa saber onde está o backend em produção. Adicione a variável de ambiente na Vercel:
+
+1. Vá em **Settings → Environment Variables**
+2. Adicione:
+
+```
+VITE_API_URL = https://dito-e-feito-backend.onrender.com
+```
+
+> ⚠️ Em seguida, verifique se o arquivo `frontend/src/services/api.js` usa `import.meta.env.VITE_API_URL` como base URL. Se ainda estiver hardcoded para `localhost:5001`, será necessário ajustar.
+
+### 2.3 Deploy
+
+Clique em **Deploy**. A Vercel vai:
+1. Instalar as dependências (`npm install`)
+2. Gerar o build de produção (`npm run build`)
+3. Publicar em uma URL como `https://dito-e-feito.vercel.app`
+
+---
+
+## 3. Desenvolvimento Local vs. Produção
+
+| | Local (Docker) | Produção |
+|---|---|---|
+| **Servidor backend** | `python api.py` (Flask dev) | `gunicorn` (WSGI) |
+| **Variáveis de ambiente** | `backend/.env` | Painel do Render |
+| **URL do backend** | `http://localhost:5001` | `https://seu-app.onrender.com` |
+| **URL do frontend** | `http://localhost:5173` | `https://seu-app.vercel.app` |
+
+### Sobrescrever o CMD para desenvolvimento local
+
+Como o Dockerfile agora usa `gunicorn` por padrão, para continuar usando o servidor de desenvolvimento Flask localmente, adicione a linha `command` no `docker-compose.yml`:
+
+```yaml
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    command: python api.py  # Sobrescreve o CMD do Dockerfile para dev local
+    ports:
+      - "5001:5001"
+    ...
+```
+
+---
+
+## 4. Checklist de Deploy
+
+- [ ] `DATABASE_URL` configurada no Render
+- [ ] `GROQ_API_KEY` configurada no Render
+- [ ] `OPENROUTER_API_KEY` configurada no Render
+- [ ] `FRONTEND_URL` configurada no Render (URL da Vercel, ex: `https://dito-e-feito.vercel.app`)
+- [ ] `VITE_API_URL` configurada na Vercel apontando para o backend do Render
+- [ ] CORS configurado automaticamente via `FRONTEND_URL` (já implementado em `api.py`)
+- [ ] Testar o endpoint `GET /api/health` após o deploy do backend
+- [ ] Testar o frontend acessando a URL da Vercel
+
+---
+
+## 5. Verificar o CORS em produção
+
+O CORS já está configurado dinamicamente em `backend/api.py` via variável de ambiente.
+Basta adicionar a variável `FRONTEND_URL` no painel do Render com a URL exata do frontend na Vercel:
+
+```
+FRONTEND_URL = https://dito-e-feito.vercel.app
+```
+
+O código em `api.py` lê automaticamente essa variável e a adiciona às origens permitidas:
+
+```python
+_FRONTEND_URL = os.environ.get("FRONTEND_URL", "")
+_CORS_ORIGINS = ["http://localhost:5173", "http://localhost:5174"]
+if _FRONTEND_URL:
+    _CORS_ORIGINS.append(_FRONTEND_URL)
+
+CORS(app, origins=_CORS_ORIGINS)
+```
+
+> ⚠️ Se o frontend da Vercel tiver uma URL diferente (ex: com subdomínio de preview), adicione também como variável de ambiente separada ou use um wildcard.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,4 @@
+# URL pública do backend no Render (sem barra no final)
+# Exemplo: https://dito-e-feito-backend.onrender.com
+# Configure esta variável em Vercel → Settings → Environment Variables
+VITE_API_URL=https://dito-e-feito-backend.onrender.com

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,7 +1,13 @@
 import axios from 'axios';
 
+// Em produção: VITE_API_URL deve apontar para o Render (ex: https://dito-e-feito-backend.onrender.com)
+// Em desenvolvimento local: cai para localhost:5001 automaticamente
+const BASE_URL = import.meta.env.VITE_API_URL
+  ? `${import.meta.env.VITE_API_URL}/api`
+  : 'http://localhost:5001/api';
+
 export const api = axios.create({
-  baseURL: 'http://localhost:5001/api', // Servidor Flask roda na porta 5001
+  baseURL: BASE_URL,
   
   // Timeout de 90 segundos (90000ms). O BERT pode ser lento sem GPU.
   timeout: 90000, 
@@ -61,8 +67,11 @@ export const getDashboardMetrics = async () => {
 };
 
 export const getMetricsJson = async () => {
+  const metricsUrl = import.meta.env.VITE_API_URL
+    ? `${import.meta.env.VITE_API_URL}/dashboard_metrics.json`
+    : 'http://localhost:5001/dashboard_metrics.json';
   try {
-    const response = await axios.get('http://localhost:5001/dashboard_metrics.json', {
+    const response = await axios.get(metricsUrl, {
       timeout: 30000,
     });
     return response.data;


### PR DESCRIPTION
- frontend/api.js: substituir localhost hardcoded por VITE_API_URL (env var do Vite) com fallback automatico para localhost:5001 em dev
- backend/api.py: CORS dinamico via FRONTEND_URL (lido do ambiente), permite localhost:5173/5174 e a URL da Vercel em producao
- backend/.dockerignore: corrigir exclusao de *.json que bloqueava dashboard_metrics.json (fallback critico da API sem banco)
- frontend/.env.example: template com VITE_API_URL para a Vercel
- docs/DEPLOY.md: atualizar com FRONTEND_URL no Render e CORS automatico